### PR TITLE
feat: adding checkUserOnSignIn to auth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chicas Programando
 
-> Esta plataforma fue creada para pormover los perfiles de mujeres en tecnología. Nuestro stack se conforma de Vue.js para el front-end y Ruby on Rails para el back-end.
+> Esta plataforma fue creada para pormover los perfiles de mujeres en tecnología. Nuestro stack se conforma de Vue.js para el front-end y Node.js para el back-end.
 
 # Documentación
 Acá dejamos algunos datos útiles para el área de desarrollo de la plataforma.
@@ -32,7 +32,7 @@ router.beforeEach((to, from, next) => {
   // set global ui understanding of authentication
   Store.commit("SET_USER_IS_AUTH", routerAuthCheck);
 
-  // check if the route to be accessed requires authorizaton
+  // check if the route to be accessed requires auth
   if (to.matched.some(record => record.meta.requiresAuth)) {
     // Check if user is Authenticated
     if (routerAuthCheck) {
@@ -49,3 +49,49 @@ router.beforeEach((to, from, next) => {
   }
 });
 ```
+
+### Store Modules Explanation
+En el index de `/store` vamos a encontrar algo como esto:
+
+```
+import Vue from "vue";
+import Vuex from "vuex";
+import auth from "./auth";
+import user from "./user";
+import profile from "./profile";
+import errors from "./errors";
+import shared from "./shared";
+
+Vue.use(Vuex);
+
+export default new Vuex.Store({
+  modules: {
+    auth,
+    user,
+    profile,
+    errors,
+    shared
+  }
+});
+```
+
+Lo que quisimos hacer en la plataforma fue tener las diferentes llamadas ordenadas por categoría. En general estamos intentando que cada sector del store represente cada sector del backend para que ambos dos laburen en conjunto y se puedan entender. Por ende, cada módulo tiene sus propios `getters`, `mutations` y `actions`. Entonces si en el back se crea una nueva ruta llamada `/projects`, nuestro store debería tener un modulo nuevo llamado `projects` también.
+
+### Auth0 Explanation
+
+En la plataforma usamos `Auth0` para nuestra autenticación de usuarios. Y nuestro flujo es el siguiente:
+
+- Entramos al login y nos redirige a Auth0
+- Elegimos con que red social/mail nos queremos registrar
+- Auth0 no devuelve unos tokens y el mail del usuario seleccionado
+- Usamos ese mail para pegarle a nuestro back para ver si el usuario existe y sino lo creamos
+
+### Profile vs User
+Hay grandes diferencias entre lo que es un perfil y lo que es un usuario. El usuario se va a usar para cosas de alto nivel mientras que el perfil será lo que se muestre al publico. 
+
+**Flujo de usuario y perfil:**
+- Se crea un usuario sin perfil
+- Para crear el perfil uno tiene que aceptar nuestro codigo de conducta
+- La primera vez que ingresemos nuestro perfil se creara un perfil dentro de nuestro usuario en la base de datos
+- Las proximas modificaciones de nuestro perfil seran directo sobre el mismo
+- Si queremos eliminar nuestro perfil de chicas programando debemos eliminar el usuario

--- a/src/store/auth/index.js
+++ b/src/store/auth/index.js
@@ -36,7 +36,7 @@ const actions = {
           err,
           user
         ) {
-          dispatch("createUser", user);
+          dispatch("checkUserOnSignIn", user);
           commit("SET_USER_IS_AUTH", true);
         });
       } else if (err) {

--- a/src/store/profile/index.js
+++ b/src/store/profile/index.js
@@ -37,6 +37,7 @@ const actions = {
         const { data } = res.data;
         context.dispatch("getProfile", data.id);
         context.dispatch("getUser", { id: user.id });
+        router.replace("/community");
       })
       .catch(e => {
         const { message } = e.response.data;

--- a/src/store/profile/index.js
+++ b/src/store/profile/index.js
@@ -30,13 +30,14 @@ const actions = {
       ...payload,
       UserId: user.id
     };
-
+    // first time the user posts a profile it needs the user id
     axios
       .post(`${process.env.VUE_APP_API_URL}/api/profile`, profileInfo)
       .then(res => {
         const { data } = res.data;
         context.dispatch("getProfile", data.id);
         context.dispatch("getUser", { id: user.id });
+        // profile should appear in /community updated
         router.replace("/community");
       })
       .catch(e => {
@@ -52,6 +53,7 @@ const actions = {
       .then(res => {
         const { data } = res.data;
         context.commit("SET_PROFILE_INFO", data);
+        // profile should appear in /community
         router.replace("/community");
       })
       .catch(e => {
@@ -81,6 +83,7 @@ const actions = {
 const getters = {
   getProfileData: state => {
     if (state.profile.specialty && state.profile.skill) {
+      // we need to format these two things to use them with the autocomplete input
       const formatedSpecialties = formatListForAutoSelect(
         state.profile.specialty
       );

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -13,6 +13,7 @@ const mutations = {
 const actions = {
   checkUserOnSignIn(context, payload) {
     const { name, nickname, email, sub, given_name } = payload;
+    // checks if the user exists with the email returned by auth0
     axios
       .post(`${process.env.VUE_APP_API_URL}/api/user/signin`, { email: email })
       .then(res => {
@@ -27,6 +28,7 @@ const actions = {
       })
       .catch(e => {
         const { status } = e.response;
+        // when de user doesn't exist it creates a new one using auth0 info
         if (status === 404) {
           const body = {
             user_name: nickname || name || given_name,
@@ -113,19 +115,6 @@ const actions = {
     } else {
       router.replace("/");
     }
-  },
-  updateUserName(context, payload) {
-    const user = context.getters.getUserData;
-    axios
-      .put(`${process.env.VUE_APP_API_URL}/api/user/${user.id}`, payload)
-      .then(res => {
-        const { data } = res.data;
-        context.commit("SET_USER_INFO", data);
-      })
-      .catch(e => {
-        // eslint-disable-next-line
-        console.log(e);
-      });
   }
 };
 const getters = {

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -11,6 +11,38 @@ const mutations = {
   }
 };
 const actions = {
+  checkUserOnSignIn(context, payload) {
+    const { name, nickname, email, sub, given_name } = payload;
+    axios
+      .post(`${process.env.VUE_APP_API_URL}/api/user/signin`, { email: email })
+      .then(res => {
+        const { data } = res.data;
+        localStorage.setItem("user_id", data.id);
+        context.commit("SET_USER_INFO", data);
+        // accepted terms and profile completion flow
+        context.dispatch("userAcceptanceFlow");
+        if (data.profile) {
+          context.dispatch("getProfile");
+        }
+      })
+      .catch(e => {
+        const { status } = e.response;
+        if (status === 404) {
+          const body = {
+            user_name: nickname || name || given_name,
+            auth_sub: sub,
+            email: email
+          };
+          context.dispatch("createUser", body);
+        } else {
+          // clear localStorage from all the things we saved previously
+          localStorage.clear();
+
+          context.commit("SET_ERROR_MSJ", e.response.data.message);
+          router.replace("/error");
+        }
+      });
+  },
   getUser(context, payload) {
     const { id } = payload;
     axios
@@ -18,9 +50,12 @@ const actions = {
       .then(res => {
         const { data } = res.data;
         context.commit("SET_USER_INFO", data);
-        // accepted terms and profile completion flow
-        context.dispatch("userAcceptanceFlow");
+        if (!data.accepted_terms) {
+          // accepted terms and profile completion flow
+          context.dispatch("userAcceptanceFlow");
+        }
         if (data.profile) {
+          // if profile exists get it
           context.dispatch("getProfile");
         }
       })
@@ -34,14 +69,8 @@ const actions = {
       });
   },
   createUser(context, payload) {
-    const { name, nickname, email, sub, given_name } = payload;
-    const body = {
-      user_name: nickname || name || given_name,
-      auth_sub: sub,
-      email: email
-    };
     axios
-      .post(`${process.env.VUE_APP_API_URL}/api/user/`, body)
+      .post(`${process.env.VUE_APP_API_URL}/api/user/`, payload)
       .then(res => {
         const { data } = res.data;
         localStorage.setItem("user_id", data.id);
@@ -51,20 +80,10 @@ const actions = {
       })
       .catch(e => {
         const { message } = e.response.data;
-        // TODO: this is just a work around
-        const user_id = message
-          .split(":")
-          .pop()
-          .split(";")[0];
-        if (user_id) {
-          localStorage.setItem("user_id", user_id);
-          context.dispatch("getUser", { id: user_id });
-        } else {
-          // clear localStorage from all the things we saved previously
-          localStorage.clear();
-          context.commit("SET_ERROR_MSJ", message);
-          router.replace("/error");
-        }
+        // clear localStorage from all the things we saved previously
+        localStorage.clear();
+        context.commit("SET_ERROR_MSJ", message);
+        router.replace("/error");
       });
   },
   acceptedTerms(context, payload) {
@@ -89,7 +108,7 @@ const actions = {
     const user = context.getters.getUserData;
     if (!user.accepted_terms) {
       router.replace("/terms");
-    } else if (!user.completed_profile) {
+    } else if (!user.profile) {
       router.replace("/profile");
     } else {
       router.replace("/");


### PR DESCRIPTION
We added a new `/api/user/signin` rout in the back end to be able to check if the user exists after auth0 authentication process

We pass a body of {email: "email"} and it should return either the user or 404 when the user doesn't exist

If the user doesn't exist then we create a new one with auth0 info